### PR TITLE
Move the scripts to the bottom, make sure the DOM is ready

### DIFF
--- a/src/ch05/io_monad_tests/io_monad_test.html
+++ b/src/ch05/io_monad_tests/io_monad_test.html
@@ -2,9 +2,6 @@
 <html>
 <head>
 
-<script src="https://cdn.rawgit.com/lodash/lodash/4.5.1/dist/lodash.min.js"></script>
-<script src="io_monad_test.js"></script>  
-
 <meta name="description" content="IO Monad">
 <meta charset="utf-8">
 <title>Playing with IO Monad</title>
@@ -15,6 +12,9 @@
     Using the IO Monad to cause side effects to happen 
     functionally
   -->
-  <div id="student-name">alonzo church</div>  
+  <div id="student-name">alonzo church</div>
+
+  <script src="https://cdn.rawgit.com/lodash/lodash/4.5.1/dist/lodash.min.js"></script>
+  <script src="io_monad_test.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Originally the script tags inside the `head` tag. When running this in the browser the element couldn't be found. I moved it to the bottom and the scripts run as expected.